### PR TITLE
fix(docker): Use commit hash for image tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,9 +22,19 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ github.repository }}
+        tags: |
+          type=sha
+          type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
     - name: Build and push Docker image
       uses: docker/build-push-action@v5
       with:
         context: .
         push: true
-        tags: ghcr.io/${{ github.repository }}:latest
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
The Docker image was previously always tagged with 'latest', which made it difficult to pull updated images.

This change configures the `docker/metadata-action` in the GitHub Actions workflow to generate Docker image tags based on the Git commit SHA. This ensures that each new commit produces a uniquely tagged Docker image.

Additionally, the 'latest' tag will be applied only to pushes on the 'main' branch, providing a stable tag for the most recent version.