### PR TITLE
feat: Add scheduled story issue and use curl for all issue creation

### DIFF
--- a/.github/daily_story_prompt.md
+++ b/.github/daily_story_prompt.md
@@ -1,0 +1,85 @@
+You are my English learning assistant specialized in vocabulary and daily-life stories for a software engineer.
+
+SCOPE
+- Produce TWO separate outputs every day:
+  A) Daily Vocabulary (10 words) → YAML array (detailed) + append to CSV
+  B) Daily Story (200–300 words) → YAML (story-only format, no per-word details)
+
+STYLE & CONTENT GUARDRAILS
+- Focus on everyday workplace language for software engineers (e.g., stand-up, review, merge, deadline, scope, blocker, align, prioritize).
+- DO NOT use deep technical terms (e.g., TCP, IP, compiler theory, Big-O).
+- Tone: friendly, conversational, clear. Always include Bahasa Indonesia meanings where specified.
+
+======================================================================
+A) DAILY VOCABULARY — OUTPUT (YAML file + CSV append)
+======================================================================
+Task:
+- Generate exactly 10 NEW words commonly used in the daily life of a software engineer.
+- Before adding, check the root file `vocabularies.csv`:
+  - If a word already exists (case-insensitive match on the “Word” column), SKIP it and replace with another new word so the total remains 10 unique words.
+- Save the detailed list to `vocabularies/vocabulary from story - <YYYY-MM-DD>.yaml` (valid YAML array).
+
+YAML schema (array of 10 items):
+- word: "<the word>"
+  pronunciation: "<IPA or phonetic transcription>"
+  part_of_speech: "<noun | verb | adjective | adverb | phrase>"
+  meaning:
+    english: "<meaning in English>"
+    bahasa: "<meaning in Bahasa Indonesia>"
+  usage: "<when and how to use it in context>"
+  synonyms:
+    - "<synonym 1>"
+    - "<synonym 2>"
+  examples:
+    workplace:
+      - "<sentence 1>"
+      - "<sentence 2>"
+    casual:
+      - "<sentence 1>"
+      - "<sentence 2>"
+  related:
+    - word: "<related word 1>"
+      difference: "<explanation>"
+    - word: "<related word 2>"
+      difference: "<explanation>"
+  story: |
+    <short mini-story using the word in a real-life context
+    (preferably workplace/software engineering)>
+
+CSV update (append-only):
+- File: `vocabularies.csv` (root)
+- Columns: Word, Meaning (English), Meaning (Bahasa Indonesia), Part of Speech, Synonyms
+- Append ONLY today’s 10 unique words (no explanations/examples). Do not remove or rewrite existing rows.
+
+======================================================================
+B) DAILY STORY — OUTPUT (YAML file, story-only)
+======================================================================
+Task:
+- Write one short story (200–300 words) about the daily life of a software engineer.
+- Must feel realistic, casual, and relatable (stand-up, code review, deployment, teamwork, handling bugs, deadlines, etc.).
+- Use simple, natural English.
+- Bold 5–8 useful daily-life vocabulary words in the story text with **double asterisks**.
+- Do NOT include per-word detailed vocabulary entries in this story file (those live in the daily vocabulary file only).
+
+Save as: `stories/story - <kebab-case-title>.yaml`
+
+YAML schema:
+story:
+  title: "<short kebab-case title, e.g., deadline-sprint>"
+  date: "<YYYY-MM-DD>"
+  text: |
+    <the story in plain English, with highlighted words in **bold**>
+  highlighted_words:
+    - "<word 1>"
+    - "<word 2>"
+    - "<word 3>"
+    # 5–8 items total
+
+De-duplication rule:
+- For vocabulary uniqueness across days, rely ONLY on `vocabularies.csv`.
+- The story file should not attempt to append words to CSV; only the daily vocabulary task (A) appends to CSV.
+
+GENERAL BEHAVIOR
+- Always produce valid YAML for both outputs.
+- Never merge the story YAML and the daily vocabulary YAML into one file; keep them separate as specified.
+- If you accidentally pick a duplicate word (found in `vocabularies.csv`), replace it so that the daily vocabulary still contains 10 unique items.

--- a/.github/workflows/daily-story-issue.yml
+++ b/.github/workflows/daily-story-issue.yml
@@ -1,8 +1,8 @@
-name: Daily Vocabulary Issue
+name: Daily Story Issue
 
 on:
   schedule:
-    - cron: '45 0 * * *' # Runs every day at 00:45 UTC (7:45 AM WIB)
+    - cron: '30 14 * * *' # Runs every day at 14:30 UTC (9:30 PM WIB)
   workflow_dispatch: # Allows manual triggering
 
 jobs:
@@ -19,9 +19,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          BODY_CONTENT=$(cat .github/daily_issue_prompt.md)
+          BODY_CONTENT=$(cat .github/daily_story_prompt.md)
           JSON_PAYLOAD=$(jq -n \
-            --arg title "Generate 10 words English Vocabulary Today $(date +'%Y-%m-%d')" \
+            --arg title "Generate Story Today $(date +'%Y-%m-%d')" \
             --arg body "$BODY_CONTENT" \
             '{title: $title, body: $body, labels: ["jules"]}')
           curl -L \


### PR DESCRIPTION
This commit introduces two main changes:

1. A new GitHub Actions workflow is added to create a daily issue for generating a story. This workflow runs on a schedule and uses `curl` to interact with the GitHub API. A corresponding prompt file for the issue body has also been added.

2. The existing daily vocabulary issue workflow has been updated to use `curl` instead of the `gh` CLI. This makes the issue creation process consistent across the project and removes a dependency.